### PR TITLE
Implement WHOOP summaries, habit tracker, GPT /ask command

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1,22 +1,29 @@
 import os
 import asyncio
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+import random
 
 from aiogram import Bot, Dispatcher, types, F
 from aiogram.filters import Command
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from fastapi import FastAPI, Request
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 import uvicorn
+import openai
 
 TG_TOKEN = os.getenv("TG_TOKEN")
 USER_CHAT_ID = os.getenv("USER_CHAT_ID")
 WHOOP_DATA_FILE = os.getenv("WHOOP_DATA_FILE", "whoop_data.json")
 MORNING_CHECKIN_FILE = os.getenv("MORNING_CHECKIN_FILE", "morning_checkins.json")
+HABITS_FILE = os.getenv("HABITS_FILE", "habits.json")
+HABIT_LOG_FILE = os.getenv("HABIT_LOG_FILE", "habit_log.json")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 bot = Bot(token=TG_TOKEN)
 dp = Dispatcher()
 app = FastAPI()
+scheduler = AsyncIOScheduler(timezone="UTC")
 
 # Reply‑keyboard с основными командами
 kb = ReplyKeyboardMarkup(
@@ -31,18 +38,48 @@ kb = ReplyKeyboardMarkup(
 )
 
 
-def load_latest_whoop_data() -> dict | None:
+def _read_whoop_lines() -> list[dict]:
     if not os.path.exists(WHOOP_DATA_FILE):
-        return None
+        return []
+    records: list[dict] = []
     try:
         with open(WHOOP_DATA_FILE, "r", encoding="utf-8") as f:
-            lines = [line for line in f if line.strip()]
-        if not lines:
-            return None
-        return json.loads(lines[-1])
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except Exception:
+                    continue
     except Exception as e:
         print("Failed to read WHOOP data:", e)
-        return None
+    return records
+
+
+def load_whoop_data(days: int | None = None) -> list[dict]:
+    records = _read_whoop_lines()
+    if days is None:
+        return records
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    filtered: list[dict] = []
+    for r in records:
+        ts = r.get("timestamp")
+        if ts:
+            try:
+                dt = datetime.fromisoformat(ts)
+                if dt >= cutoff:
+                    filtered.append(r)
+            except Exception:
+                filtered.append(r)
+        else:
+            filtered.append(r)
+    return filtered
+
+
+def load_latest_whoop_data() -> dict | None:
+    records = _read_whoop_lines()
+    return records[-1] if records else None
 
 
 def save_morning_checkin(user_id: int, response: str) -> None:
@@ -57,6 +94,46 @@ def save_morning_checkin(user_id: int, response: str) -> None:
             f.write("\n")
     except Exception as e:
         print("Failed to save morning check-in:", e)
+
+
+def load_habits() -> dict:
+    if not os.path.exists(HABITS_FILE):
+        return {}
+    try:
+        with open(HABITS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_habits(data: dict) -> None:
+    try:
+        with open(HABITS_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
+    except Exception as e:
+        print("Failed to save habits:", e)
+
+
+def add_habit(user_id: int, habit: str) -> None:
+    data = load_habits()
+    habits = set(data.get(str(user_id), []))
+    habits.add(habit)
+    data[str(user_id)] = sorted(habits)
+    save_habits(data)
+
+
+def log_habit_completion(user_id: int, habit: str) -> None:
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "user_id": user_id,
+        "habit": habit,
+    }
+    try:
+        with open(HABIT_LOG_FILE, "a", encoding="utf-8") as f:
+            json.dump(entry, f, ensure_ascii=False)
+            f.write("\n")
+    except Exception as e:
+        print("Failed to log habit completion:", e)
 
 
 @dp.message(F.text == "/start")
@@ -135,6 +212,63 @@ async def notes_handler(message: types.Message):
     await message.answer("Заметка сохранена ✅")
 
 
+@dp.message(Command("addhabit"))
+async def addhabit_handler(message: types.Message):
+    text = message.text.split(maxsplit=1)
+    if len(text) < 2:
+        await message.answer("Использование: /addhabit название_привычки")
+        return
+    habit = text[1].strip()
+    add_habit(message.from_user.id, habit)
+    await message.answer(f"Добавлена привычка: {habit}")
+
+
+@dp.message(Command("done"))
+async def done_handler(message: types.Message):
+    text = message.text.split(maxsplit=1)
+    if len(text) < 2:
+        await message.answer("Использование: /done название_привычки")
+        return
+    habit = text[1].strip()
+    log_habit_completion(message.from_user.id, habit)
+    await message.answer(f"Отмечено выполнение: {habit}")
+
+
+@dp.message(Command("habits"))
+async def habits_handler(message: types.Message):
+    habits = load_habits().get(str(message.from_user.id), [])
+    if not habits:
+        await message.answer("Привычки не заданы. Используй /addhabit")
+    else:
+        await message.answer("Твои привычки:\n- " + "\n- ".join(habits))
+
+
+@dp.message(Command("ask"))
+async def ask_handler(message: types.Message):
+    text = message.text.split(maxsplit=1)
+    if len(text) < 2:
+        await message.answer("Использование: /ask вопрос")
+        return
+    question = text[1]
+    openai.api_key = OPENAI_API_KEY
+    try:
+        resp = await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": "You are a helpful health assistant."},
+                    {"role": "user", "content": question},
+                ],
+            ),
+        )
+        answer = resp["choices"][0]["message"]["content"].strip()
+    except Exception as e:
+        print("GPT error:", e)
+        answer = "Не удалось получить ответ."
+    await message.answer(answer)
+
+
 @dp.message()
 async def fallback_handler(message: types.Message):
     await message.answer("Используй кнопки ниже или введи команду вручную.")
@@ -144,9 +278,13 @@ async def fallback_handler(message: types.Message):
 async def whoop_webhook(request: Request):
     data = await request.json()
     # Сохраняем WHOOP-данные
+    data_with_ts = {
+        **data,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
     try:
         with open(WHOOP_DATA_FILE, "a", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False)
+            json.dump(data_with_ts, f, ensure_ascii=False)
             f.write("\n")
     except Exception as e:
         print("Failed to save WHOOP data:", e)
@@ -161,12 +299,101 @@ async def whoop_webhook(request: Request):
     return {"ok": True}
 
 
+async def send_daily_whoop_summary():
+    if not USER_CHAT_ID:
+        return
+    data = load_latest_whoop_data()
+    if not data:
+        return
+    sleep = data.get("sleep")
+    recovery = data.get("recovery")
+    strain = data.get("strain")
+    steps = data.get("steps")
+    hrv = data.get("hrv")
+    tips = [
+        "Сделайте лёгкую растяжку сегодня.",
+        "Не забывайте про воду в течение дня.",
+        "Короткая медитация поможет сосредоточиться.",
+    ]
+    report = [
+        f"Сон: {sleep} ч." if sleep is not None else "Данных о сне нет.",
+        f"Восстановление {recovery}%" if recovery is not None else "Нет данных о восстановлении.",
+        f"Нагрузка {strain}" if strain is not None else "Нет данных о нагрузке.",
+        f"HRV {hrv}" if hrv is not None else "Нет данных HRV.",
+        f"Шаги {steps}" if steps is not None else "Нет данных о шагах.",
+        random.choice(tips),
+    ]
+    await bot.send_message(USER_CHAT_ID, "\n".join(report))
+
+
+async def send_habit_reminder():
+    if not USER_CHAT_ID:
+        return
+    habits = load_habits().get(str(USER_CHAT_ID), [])
+    if not habits:
+        return
+    text = "Напоминание о привычках:\n- " + "\n- ".join(habits)
+    text += "\nОтметь выполнение: /done название_привычки"
+    await bot.send_message(USER_CHAT_ID, text)
+
+
+async def smart_reminders():
+    if not USER_CHAT_ID:
+        return
+    data = load_latest_whoop_data()
+    if not data:
+        return
+    messages = []
+    recovery = data.get("recovery")
+    steps = data.get("steps")
+    if recovery is not None and recovery < 60:
+        messages.append("Сегодня восстановление низкое. Лучше отдохнуть.")
+    if steps is not None and steps < 5000:
+        messages.append("К вечеру меньше 5000 шагов. Прогуляйтесь!")
+    for msg in messages:
+        await bot.send_message(USER_CHAT_ID, msg)
+
+
+def _average(lst):
+    return sum(lst) / len(lst) if lst else None
+
+
+async def send_weekly_report():
+    if not USER_CHAT_ID:
+        return
+    data7 = load_whoop_data(7)
+    if not data7:
+        await bot.send_message(USER_CHAT_ID, "Нет данных WHOOP за неделю.")
+        return
+    sleep = _average([d.get("sleep") for d in data7 if d.get("sleep") is not None])
+    recovery = _average([d.get("recovery") for d in data7 if d.get("recovery") is not None])
+    strain = _average([d.get("strain") for d in data7 if d.get("strain") is not None])
+    hrv = _average([d.get("hrv") for d in data7 if d.get("hrv") is not None])
+    steps = _average([d.get("steps") for d in data7 if d.get("steps") is not None])
+    report = [
+        "Недельный отчёт WHOOP:",
+        f"Средний сон: {sleep:.1f} ч." if sleep is not None else "- сон: нет данных", 
+        f"Среднее восстановление: {recovery:.0f}%" if recovery is not None else "- восстановление: нет данных",
+        f"Средняя нагрузка: {strain:.1f}" if strain is not None else "- нагрузка: нет данных",
+        f"Средний HRV: {hrv:.1f}" if hrv is not None else "- HRV: нет данных",
+        f"Средние шаги: {steps:.0f}" if steps is not None else "- шаги: нет данных",
+    ]
+    await bot.send_message(USER_CHAT_ID, "\n".join(report))
+
+
 async def start_bot():
     await dp.start_polling(bot)
 
 
 @app.on_event("startup")
 async def on_startup() -> None:
+    scheduler.add_job(send_daily_whoop_summary, "cron", hour=8, minute=0)
+    scheduler.add_job(send_habit_reminder, "cron", hour=8, minute=30)
+    scheduler.add_job(send_habit_reminder, "cron", hour=13, minute=0)
+    scheduler.add_job(send_habit_reminder, "cron", hour=19, minute=0)
+    scheduler.add_job(smart_reminders, "cron", hour=18, minute=0)
+    scheduler.add_job(send_weekly_report, "cron", day_of_week="sun", hour=20, minute=0)
+    scheduler.start()
     asyncio.create_task(start_bot())
 
 


### PR DESCRIPTION
## Summary
- schedule daily WHOOP summary messages and weekly reports
- add habit tracker with reminders and logging
- send smart WHOOP-based reminders in the evening
- implement `/ask` command that queries OpenAI GPT for advice
- store WHOOP data with timestamps for reporting

## Testing
- `python -m py_compile run_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6883a2aee4d083259c23c8da6ad0f564